### PR TITLE
Convert RadioItems to use <button> for click events

### DIFF
--- a/src/lib/components/ContextMenu/ContextMenuRadioItem.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuRadioItem.svelte
@@ -47,11 +47,14 @@
 {#if asChild}
   <slot builder={$radioItem({ value, disabled })} />
 {:else}
-  <div
+  <button
+    type="button"
     class={cn(style.base, style({ disabled }), className)}
     use:melt={$radioItem({ value, disabled })}
+    {disabled}
     {...$$restProps}
+    on:click
   >
     <slot />
-  </div>
+  </button>
 {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenuRadioItem.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuRadioItem.svelte
@@ -47,11 +47,14 @@
 {#if asChild}
   <slot builder={$radioItem({ value, disabled })} />
 {:else}
-  <div
+  <button
+    type="button"
     class={cn(style.base, style({ disabled }), className)}
     use:melt={$radioItem({ value, disabled })}
+    {disabled}
     {...$$restProps}
+    on:click
   >
     <slot />
-  </div>
+  </button>
 {/if}


### PR DESCRIPTION
### Description

This PR converts RadioItems to use `<button>` elements instead of `<div>` so that click events and other DOM events can be properly handled.

Fixes #28 

### Changes

- `ContextMenuRadioItem` and `DropdownMenuRadioItem` components now render `button` instead of `div` 
- Added `on:click` event to `ContextMenuRadioItem` and to `DropdownMenuRadioItem`
- Added missing `disabled` prop
