### PR TITLE
Make Modal opaque

### DIFF
--- a/src/lib/components/Modal/ModalContent.svelte
+++ b/src/lib/components/Modal/ModalContent.svelte
@@ -16,8 +16,9 @@
   const style = tv({
     base: cn`
       w-full
-      bg-muted/5
+      bg-panel
       pointer-events-auto
+      
       md:max-w-lg
       md:rounded-lg
     `,


### PR DESCRIPTION
### Description
This PR fixes an issue where the Modal component has a semi-transparent background, allowing content behind it to be seen through the modal. 
Fixes #30 

### Changes
- Changed the Modal background from semi-transparent to fully opaque in `ModalContent.svelte`

### Additional Context

An opaque background on the Modal component provides a better user experience by preventing overlapping content from showing through.