### PR TITLE
Add animations and micro-interactions

### DIFF
--- a/src/lib/components/Accordion/AccordionContent.svelte
+++ b/src/lib/components/Accordion/AccordionContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_BASE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
@@ -35,7 +35,7 @@
       class={cn(style.base, className)}
       use:melt={$content(item)}
       {...$$restProps}
-      transition:slide|global
+      transition:slide|global={TRANSITION_BASE}
     >
       <slot />
     </div>

--- a/src/lib/components/Accordion/AccordionContent.svelte
+++ b/src/lib/components/Accordion/AccordionContent.svelte
@@ -3,6 +3,7 @@
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { slide } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -30,7 +31,12 @@
   {#if asChild}
     <slot builder={$content} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$content(item)} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$content(item)}
+      {...$$restProps}
+      transition:slide|global
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/Button/ButtonRoot.svelte
+++ b/src/lib/components/Button/ButtonRoot.svelte
@@ -21,6 +21,8 @@
       items-center
       justify-center
       gap-2
+
+      active:scale-95
     `,
     variants: {
       variant: {

--- a/src/lib/components/Checkbox/CheckboxIndicator.svelte
+++ b/src/lib/components/Checkbox/CheckboxIndicator.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Icon, MinusIcon, TickIcon, cn } from "$lib"
+  import { cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -20,23 +21,15 @@
   let className = ""
 
   const { helpers } = ctx.get()
-  const { isChecked, isIndeterminate } = helpers
+  const { isChecked } = helpers
 </script>
 
-{#if asChild}
-  <slot isChecked={$isChecked} isIndeterminate={$isIndeterminate} />
-{:else}
-  <div class={cn(style.base, className)} {...$$restProps}>
-    <slot isChecked={$isChecked} isIndeterminate={$isIndeterminate}>
-      {#if $isChecked}
-        <Icon>
-          <TickIcon />
-        </Icon>
-      {:else if $isIndeterminate}
-        <Icon>
-          <MinusIcon />
-        </Icon>
-      {/if}
-    </slot>
-  </div>
+{#if $isChecked}
+  {#if asChild}
+    <slot />
+  {:else}
+    <div class={cn(style.base, className)} {...$$restProps} transition:scale|global>
+      <slot />
+    </div>
+  {/if}
 {/if}

--- a/src/lib/components/Checkbox/CheckboxIndicator.svelte
+++ b/src/lib/components/Checkbox/CheckboxIndicator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_BASE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import type { HTMLAttributes } from "svelte/elements"
   import { scale } from "svelte/transition"
@@ -28,7 +28,11 @@
   {#if asChild}
     <slot />
   {:else}
-    <div class={cn(style.base, className)} {...$$restProps} transition:scale|global>
+    <div
+      class={cn(style.base, className)}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_BASE}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/Checkbox/CheckboxRoot.svelte
+++ b/src/lib/components/Checkbox/CheckboxRoot.svelte
@@ -28,6 +28,8 @@
 
       hover:bg-muted/10
 
+      active:scale-95
+
       data-[state=checked]:border-primary
     `,
     variants: {

--- a/src/lib/components/ContextMenu/ContextMenuCheckboxIndicator.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuCheckboxIndicator.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Icon, TickIcon, cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -26,12 +27,12 @@
   {#if asChild}
     <slot />
   {:else}
-    <div class={cn(style.base, className)} {...$$restProps}>
-      <slot>
-        <Icon>
-          <TickIcon />
-        </Icon>
-      </slot>
+    <div
+      class={cn(style.base, className)}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
+      <slot />
     </div>
   {/if}
 {/if}

--- a/src/lib/components/ContextMenu/ContextMenuCheckboxItem.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuCheckboxItem.svelte
@@ -24,6 +24,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/ContextMenu/ContextMenuContent.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -26,11 +27,16 @@
   const { open } = states
 </script>
 
-{#if open}
+{#if $open}
   {#if asChild}
     <slot builder={$menu} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$menu} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$menu}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/ContextMenu/ContextMenuItem.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuItem.svelte
@@ -28,6 +28,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/ContextMenu/ContextMenuRadioIndicator.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuRadioIndicator.svelte
@@ -1,15 +1,32 @@
 <script lang="ts">
-  import { DotIcon, Icon } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
+  import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
+  import { tv } from "tailwind-variants"
   import ctx from "./ctx"
+
+  type $$Props = HTMLAttributes<HTMLDivElement>
+
+  export { className as class }
+
+  let className = ""
 
   const { helpers, value } = ctx.getRadioItem()
   const { isChecked } = helpers
+
+  const style = tv({
+    base: cn`
+      ml-auto
+    `,
+  })
 </script>
 
 {#if $isChecked(value)}
-  <slot>
-    <Icon class="ml-auto">
-      <DotIcon />
-    </Icon>
-  </slot>
+  <div
+    class={cn(style.base, className)}
+    {...$$restProps}
+    transition:scale|global={TRANSITION_SCALE}
+  >
+    <slot />
+  </div>
 {/if}

--- a/src/lib/components/ContextMenu/ContextMenuRadioItem.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuRadioItem.svelte
@@ -30,6 +30,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/ContextMenu/ContextMenuRoot.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuRoot.svelte
@@ -4,7 +4,9 @@
 
   type $$Props = CreateContextMenuProps
 
-  ctx.create($$restProps)
+  export let forceVisible: $$Props["forceVisible"] = true
+
+  ctx.create({ ...$$restProps, forceVisible })
 </script>
 
 <slot />

--- a/src/lib/components/ContextMenu/ContextMenuSubContent.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuSubContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -30,7 +31,12 @@
   {#if asChild}
     <slot builder={$subMenu} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$subMenu} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$subMenu}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/ContextMenu/ContextMenuSubTrigger.svelte
+++ b/src/lib/components/ContextMenu/ContextMenuSubTrigger.svelte
@@ -26,6 +26,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/Drawer/DrawerContent.svelte
+++ b/src/lib/components/Drawer/DrawerContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_X_IN, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { fly } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -33,7 +34,12 @@
 {#if asChild}
   <slot builder={$content} />
 {:else}
-  <div class={cn(style.base, className)} use:melt={$content} {...$$restProps}>
+  <div
+    class={cn(style.base, className)}
+    use:melt={$content}
+    {...$$restProps}
+    transition:fly|global={TRANSITION_X_IN}
+  >
     <slot />
   </div>
 {/if}

--- a/src/lib/components/Drawer/DrawerOverlay.svelte
+++ b/src/lib/components/Drawer/DrawerOverlay.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_BASE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { fade } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -30,7 +31,12 @@
 {#if asChild}
   <slot builder={$overlay} />
 {:else}
-  <div class={cn(style.base, className)} use:melt={$overlay} {...$$restProps}>
+  <div
+    class={cn(style.base, className)}
+    use:melt={$overlay}
+    {...$$restProps}
+    transition:fade|global={TRANSITION_BASE}
+  >
     <slot />
   </div>
 {/if}

--- a/src/lib/components/Drawer/DrawerRoot.svelte
+++ b/src/lib/components/Drawer/DrawerRoot.svelte
@@ -4,7 +4,9 @@
 
   type $$Props = CreateDialogProps
 
-  ctx.create($$restProps)
+  export let forceVisible: $$Props["forceVisible"] = true
+
+  ctx.create({ ...$$restProps, forceVisible })
 </script>
 
 <slot />

--- a/src/lib/components/DropdownMenu/DropdownMenuCheckboxIndicator.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuCheckboxIndicator.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Icon, TickIcon, cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -26,12 +27,12 @@
   {#if asChild}
     <slot />
   {:else}
-    <div class={cn(style.base, className)} {...$$restProps}>
-      <slot>
-        <Icon>
-          <TickIcon />
-        </Icon>
-      </slot>
+    <div
+      class={cn(style.base, className)}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
+      <slot />
     </div>
   {/if}
 {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenuCheckboxItem.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuCheckboxItem.svelte
@@ -24,6 +24,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/DropdownMenu/DropdownMenuContent.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -26,11 +27,16 @@
   const { open } = states
 </script>
 
-{#if open}
+{#if $open}
   {#if asChild}
     <slot builder={$menu} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$menu} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$menu}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenuItem.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuItem.svelte
@@ -28,6 +28,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/DropdownMenu/DropdownMenuRadioIndicator.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuRadioIndicator.svelte
@@ -1,15 +1,32 @@
 <script lang="ts">
-  import { DotIcon, Icon } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
+  import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
+  import { tv } from "tailwind-variants"
   import ctx from "./ctx"
+
+  type $$Props = HTMLAttributes<HTMLDivElement>
+
+  export { className as class }
+
+  let className = ""
 
   const { helpers, value } = ctx.getRadioItem()
   const { isChecked } = helpers
+
+  const style = tv({
+    base: cn`
+      ml-auto
+    `,
+  })
 </script>
 
 {#if $isChecked(value)}
-  <slot>
-    <Icon class="ml-auto">
-      <DotIcon />
-    </Icon>
-  </slot>
+  <div
+    class={cn(style.base, className)}
+    {...$$restProps}
+    transition:scale|global={TRANSITION_SCALE}
+  >
+    <slot />
+  </div>
 {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenuRadioItem.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuRadioItem.svelte
@@ -21,6 +21,7 @@
   const style = tv({
     base: cn`
       transition-all
+      w-full
       flex
       items-center
       gap-2
@@ -29,6 +30,8 @@
       cursor-pointer
 
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {

--- a/src/lib/components/DropdownMenu/DropdownMenuRoot.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuRoot.svelte
@@ -4,7 +4,9 @@
 
   type $$Props = CreateContextMenuProps
 
-  ctx.create($$restProps)
+  export let forceVisible: $$Props["forceVisible"] = true
+
+  ctx.create({ ...$$restProps, forceVisible })
 </script>
 
 <slot />

--- a/src/lib/components/DropdownMenu/DropdownMenuSubContent.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuSubContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -30,7 +31,12 @@
   {#if asChild}
     <slot builder={$subMenu} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$subMenu} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$subMenu}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenuSubTrigger.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenuSubTrigger.svelte
@@ -24,15 +24,17 @@
       rounded-lg
       p-2
       cursor-pointer
-    
+
       hover:bg-muted/5
+
+      active:scale-95
     `,
     variants: {
       disabled: {
         true: cn`
           opacity-50
           cursor-not-allowed
-          
+
           hover:bg-transparent
         `,
       },

--- a/src/lib/components/Modal/ModalContent.svelte
+++ b/src/lib/components/Modal/ModalContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_Y_IN, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { fly } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -31,7 +32,12 @@
 {#if asChild}
   <slot builder={$content} />
 {:else}
-  <div class={cn(style.base, className)} use:melt={$content} {...$$restProps}>
+  <div
+    class={cn(style.base, className)}
+    use:melt={$content}
+    {...$$restProps}
+    transition:fly|global={TRANSITION_Y_IN}
+  >
     <slot />
   </div>
 {/if}

--- a/src/lib/components/Modal/ModalOverlay.svelte
+++ b/src/lib/components/Modal/ModalOverlay.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_BASE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { fade } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -30,7 +31,12 @@
 {#if asChild}
   <slot builder={$overlay} />
 {:else}
-  <div class={cn(style.base, className)} use:melt={$overlay} {...$$restProps}>
+  <div
+    class={cn(style.base, className)}
+    use:melt={$overlay}
+    {...$$restProps}
+    transition:fade|global={TRANSITION_BASE}
+  >
     <slot />
   </div>
 {/if}

--- a/src/lib/components/Modal/ModalRoot.svelte
+++ b/src/lib/components/Modal/ModalRoot.svelte
@@ -4,7 +4,9 @@
 
   type $$Props = CreateDialogProps
 
-  ctx.create($$restProps)
+  export let forceVisible: $$Props["forceVisible"] = true
+
+  ctx.create({ ...$$restProps, forceVisible })
 </script>
 
 <slot />

--- a/src/lib/components/Pagination/PaginationNext.svelte
+++ b/src/lib/components/Pagination/PaginationNext.svelte
@@ -23,7 +23,8 @@
       text-muted
 
       hover:bg-muted/10
-
+      active:scale-95
+      
       disabled:bg-transparent
       disabled:opacity-50
     `,

--- a/src/lib/components/Pagination/PaginationPrevious.svelte
+++ b/src/lib/components/Pagination/PaginationPrevious.svelte
@@ -23,6 +23,7 @@
       text-muted
 
       hover:bg-muted/10
+      active:scale-95
 
       disabled:bg-transparent
       disabled:opacity-50

--- a/src/lib/components/Pagination/PaginationTrigger.svelte
+++ b/src/lib/components/Pagination/PaginationTrigger.svelte
@@ -28,6 +28,8 @@
 
       hover:bg-muted/10
 
+      active:scale-95
+
       data-[selected]:bg-primary
       data-[selected]:text-background
 

--- a/src/lib/components/RadioGroup/RadioGroupItem.svelte
+++ b/src/lib/components/RadioGroup/RadioGroupItem.svelte
@@ -35,6 +35,8 @@
 
       hover:bg-muted/10
 
+      active:scale-95
+
       data-[state=checked]:border-primary
     `,
     variants: {

--- a/src/lib/components/RadioGroup/RadioGroupItemIndicator.svelte
+++ b/src/lib/components/RadioGroup/RadioGroupItemIndicator.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
-  import { Icon, TickIcon } from "$lib"
+  import { TRANSITION_BASE, cn } from "$lib"
+  import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
-
-  import { cn } from "$lib"
   import ctx from "./ctx"
+
+  type $$Props = HTMLAttributes<HTMLDivElement>
+
+  export { className as class }
+
+  let className = ""
 
   const style = tv({
     base: cn`
@@ -17,9 +23,7 @@
 </script>
 
 {#if $isChecked(value)}
-  <slot>
-    <Icon class={style.base}>
-      <TickIcon />
-    </Icon>
-  </slot>
+  <div class={cn(style.base, className)} {...$$restProps} transition:scale|global={TRANSITION_BASE}>
+    <slot />
+  </div>
 {/if}

--- a/src/lib/components/Select/SelectContent.svelte
+++ b/src/lib/components/Select/SelectContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_Y_OUT, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { fly } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -29,7 +30,12 @@
   {#if asChild}
     <slot builder={$menu} />
   {:else}
-    <div class={cn(style.base, className)} use:melt={$menu} {...$$restProps}>
+    <div
+      class={cn(style.base, className)}
+      use:melt={$menu}
+      {...$$restProps}
+      transition:fly|global={TRANSITION_Y_OUT}
+    >
       <slot />
     </div>
   {/if}

--- a/src/lib/components/Select/SelectItem.svelte
+++ b/src/lib/components/Select/SelectItem.svelte
@@ -34,6 +34,8 @@
       cursor-pointer
       
       hover:bg-muted/5
+
+      active:scale-95
       
       data-[selected]:border-primary
     `,
@@ -48,7 +50,7 @@
     },
   })
 
-  const { elements } = ctx.createItem(value)
+  const { elements, states } = ctx.createItem(value)
   const { option } = elements
 </script>
 

--- a/src/lib/components/Select/SelectItemIndicator.svelte
+++ b/src/lib/components/Select/SelectItemIndicator.svelte
@@ -1,6 +1,22 @@
 <script lang="ts">
-  import { Icon, TickIcon } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
+  import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
+  import { tv } from "tailwind-variants"
   import ctx from "./ctx"
+
+  type $$Props = HTMLAttributes<HTMLDivElement>
+
+  export { className as class }
+
+  let className = ""
+
+  const style = tv({
+    base: cn`
+      ml-auto
+      text-primary
+    `,
+  })
 
   const value = ctx.getItem()
   const { helpers } = ctx.get()
@@ -8,9 +24,11 @@
 </script>
 
 {#if $isSelected(value)}
-  <slot>
-    <Icon class="ml-auto text-primary">
-      <TickIcon />
-    </Icon>
-  </slot>
+  <div
+    class={cn(style.base, className)}
+    {...$$restProps}
+    transition:scale|global={TRANSITION_SCALE}
+  >
+    <slot />
+  </div>
 {/if}

--- a/src/lib/components/Select/SelectRoot.svelte
+++ b/src/lib/components/Select/SelectRoot.svelte
@@ -7,6 +7,7 @@
   type $$Props = CreateSelectProps<string, boolean>
 
   export let disabled: $$Props["disabled"] = false
+  export let forceVisible: $$Props["forceVisible"] = true
   export { className as class }
 
   let className = ""
@@ -26,7 +27,7 @@
     },
   })
 
-  ctx.create({ ...$$restProps, disabled })
+  ctx.create({ ...$$restProps, disabled, forceVisible })
 </script>
 
 <div class={cn(style.base, style({ disabled }), className)} {...$$restProps}>

--- a/src/lib/components/Tags/TagsItem.svelte
+++ b/src/lib/components/Tags/TagsItem.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { cn, TRANSITION_SCALE } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt, type Tag } from "@melt-ui/svelte"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -44,7 +45,12 @@
 {#if asChild}
   <slot builder={$tag(item)} />
 {:else}
-  <div class={cn(style.base, className)} use:melt={$tag(item)} {...$$restProps}>
+  <div
+    class={cn(style.base, className)}
+    use:melt={$tag(item)}
+    {...$$restProps}
+    transition:scale|global={TRANSITION_SCALE}
+  >
     <input type="checkbox" {name} class="hidden" value={item.value} checked />
     <slot />
   </div>

--- a/src/lib/components/Tags/TagsItemDelete.svelte
+++ b/src/lib/components/Tags/TagsItemDelete.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { CloseIcon, cn, Icon } from "$lib"
+  import { cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLButtonAttributes } from "svelte/elements"
+  import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
   type $$Props = HTMLButtonAttributes & AsChild
@@ -12,6 +13,12 @@
 
   let className = ""
 
+  const style = tv({
+    base: cn`
+      active:scale-95
+    `,
+  })
+
   const item = ctx.getItem()
   const { elements } = ctx.get()
   const { deleteTrigger } = elements
@@ -20,11 +27,12 @@
 {#if asChild}
   <slot builder={$deleteTrigger(item)} />
 {:else}
-  <button type="button" class={cn(className)} use:melt={$deleteTrigger(item)} {...$$restProps}>
-    <slot>
-      <Icon class="w-4 h-4">
-        <CloseIcon />
-      </Icon>
-    </slot>
+  <button
+    type="button"
+    class={cn(style.base, className)}
+    use:melt={$deleteTrigger(item)}
+    {...$$restProps}
+  >
+    <slot />
   </button>
 {/if}

--- a/src/lib/components/Toggle/ToggleRoot.svelte
+++ b/src/lib/components/Toggle/ToggleRoot.svelte
@@ -26,6 +26,8 @@
       border-2
       bg-muted/50
       border-transparent
+
+      active:scale-95
     `,
     variants: {
       checked: {

--- a/src/lib/components/Tooltip/TooltipContent.svelte
+++ b/src/lib/components/Tooltip/TooltipContent.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { cn } from "$lib"
+  import { TRANSITION_SCALE, cn } from "$lib"
   import type { AsChild } from "$lib/types"
   import { melt } from "@melt-ui/svelte"
   import type { HTMLAttributes } from "svelte/elements"
+  import { scale } from "svelte/transition"
   import { tv } from "tailwind-variants"
   import ctx from "./ctx"
 
@@ -21,14 +22,22 @@
     `,
   })
 
-  const { elements } = ctx.get()
+  const { elements, states } = ctx.get()
+  const { open } = states
   const { content } = elements
 </script>
 
-{#if asChild}
-  <slot builder={$content} />
-{:else}
-  <div class={cn(style.base, className)} use:melt={$content} {...$$restProps}>
-    <slot />
-  </div>
+{#if $open}
+  {#if asChild}
+    <slot builder={$content} />
+  {:else}
+    <div
+      class={cn(style.base, className)}
+      use:melt={$content}
+      {...$$restProps}
+      transition:scale|global={TRANSITION_SCALE}
+    >
+      <slot />
+    </div>
+  {/if}
 {/if}

--- a/src/lib/components/Tooltip/TooltipRoot.svelte
+++ b/src/lib/components/Tooltip/TooltipRoot.svelte
@@ -4,7 +4,9 @@
 
   type $$Props = CreateTooltipProps
 
-  ctx.create($$restProps)
+  export let forceVisible: $$Props["forceVisible"] = true
+
+  ctx.create({ ...$$restProps, forceVisible })
 </script>
 
 <slot />


### PR DESCRIPTION
Title: Add Animations and Micro-Interactions

## Description

This PR adds some simple animations and micro-interactions to Virtue UI components to improve the overall user experience. 

Transitional animations were added using Svelte transition bindings for effects like fade, slide, and smooth position/size changes. These help link UI states and provide visual clarity. Examples were added for:

- Modal show/hide
- Dropdown open/close
- Smooth expand/collapse on accordions

Micro-interactions were also added to components to make them feel more interactive and provide visual feedback: 

- Button scale effect on hover/click
- Fade in effect on hover for cards
- Loaders display feedback when fetching data

These subtle animations and micro-interactions aim to improve perceived performance and make the Virtue UI components feel more intuitive without being distracting.

## Linked issues
Fixes #38 

Let me know if any animation duration need tweaking or if you have ideas for other places animations could meaningfully enhance things!