### PR TITLE
Normalized spacing

### DIFF
--- a/src/lib/components/Accordion/AccordionContent.svelte
+++ b/src/lib/components/Accordion/AccordionContent.svelte
@@ -17,7 +17,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 

--- a/src/lib/components/Accordion/AccordionTrigger.svelte
+++ b/src/lib/components/Accordion/AccordionTrigger.svelte
@@ -17,7 +17,7 @@
     base: cn`
       w-full
       text-left
-      p-4
+      p-5
       flex
       items-center
       justify-between

--- a/src/lib/components/Alert/AlertRoot.svelte
+++ b/src/lib/components/Alert/AlertRoot.svelte
@@ -16,7 +16,7 @@
       rounded-lg
       flex
       items-center
-      p-4
+      p-5
       gap-2
     `,
     variants: {

--- a/src/lib/components/AppPage/AppPageContent.svelte
+++ b/src/lib/components/AppPage/AppPageContent.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/AppPage/AppPageHeader.svelte
+++ b/src/lib/components/AppPage/AppPageHeader.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       flex
       items-center
       justify-between

--- a/src/lib/components/Button/ButtonRoot.svelte
+++ b/src/lib/components/Button/ButtonRoot.svelte
@@ -15,7 +15,7 @@
   const style = tv({
     base: cn`
       transition-all
-      p-4
+      p-5
       rounded-lg
       flex
       items-center

--- a/src/lib/components/Card/CardContent.svelte
+++ b/src/lib/components/Card/CardContent.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/Card/CardFooter.svelte
+++ b/src/lib/components/Card/CardFooter.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/Card/CardHeader.svelte
+++ b/src/lib/components/Card/CardHeader.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/Drawer/DrawerHeader.svelte
+++ b/src/lib/components/Drawer/DrawerHeader.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       flex
       items-center
       justify-between

--- a/src/lib/components/Drawer/DrawerInner.svelte
+++ b/src/lib/components/Drawer/DrawerInner.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       h-full
     `,
   })

--- a/src/lib/components/Form/FormRoot.svelte
+++ b/src/lib/components/Form/FormRoot.svelte
@@ -16,7 +16,7 @@
     base: cn`
       flex
       flex-col
-      gap-4
+      gap-5
     `,
   })
 </script>

--- a/src/lib/components/Modal/ModalFooter.svelte
+++ b/src/lib/components/Modal/ModalFooter.svelte
@@ -10,7 +10,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       flex
       gap-2
       items-center

--- a/src/lib/components/Modal/ModalHeader.svelte
+++ b/src/lib/components/Modal/ModalHeader.svelte
@@ -10,7 +10,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       flex
       flex-col
     `,

--- a/src/lib/components/Modal/ModalInner.svelte
+++ b/src/lib/components/Modal/ModalInner.svelte
@@ -9,7 +9,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 

--- a/src/lib/components/Nav/NavBrand.svelte
+++ b/src/lib/components/Nav/NavBrand.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/Nav/NavFooter.svelte
+++ b/src/lib/components/Nav/NavFooter.svelte
@@ -12,7 +12,7 @@
   const style = tv({
     base: cn`
       mt-auto
-      p-4
+      p-5
     `,
   })
 </script>

--- a/src/lib/components/Nav/NavUl.svelte
+++ b/src/lib/components/Nav/NavUl.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       flex
       flex-col
       gap-2

--- a/src/lib/components/Table/TableCell.svelte
+++ b/src/lib/components/Table/TableCell.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       align-middle
     `,
   })

--- a/src/lib/components/Table/TableHead.svelte
+++ b/src/lib/components/Table/TableHead.svelte
@@ -11,7 +11,7 @@
 
   const style = tv({
     base: cn`
-      p-4
+      p-5
       text-left
       align-middle
     `,


### PR DESCRIPTION
## Description:

This PR aims to improve consistency around spacing between elements by standardizing on the p-5 padding utility (3rem). 

Currently, there is a mix of p-4 (1.5rem) and p-5 (3rem) padding used, leading to inconsistent gaps between sections on pages.

## Changes

- Replace all uses of `p-4` with `p-5`
    - This increases spacing from 1.5rem to 3rem 
- Related CSS also updated

## Benefits

- More consistent spacing between visual elements
- Improves readability and accessibility 
- Increased breathing room overall

## Linked issues
Fixes #39 

Let me know if any sections need different padding treatment or any other feedback!