### PR TITLE
Button href

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtue-ui",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "url": "https://github.com/virtueorg/ui"
   },

--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -8,12 +8,14 @@
   type $$Props = HTMLButtonAttributes &
     AsChildType & {
       variant?: ExtendedVariantType
-      builders?: any[]
+      builders?: BuilderType[]
+      href?: string
     }
 
   export let asChild: $$Props["asChild"] = false
   export let type: $$Props["type"] = "button"
   export let variant: $$Props["variant"] = "default"
+  export let href: $$Props["href"] = ""
   export let builders: $$Props["builders"] = []
   export { className as class }
 

--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -141,6 +141,8 @@
   })
 
   const builderActions = (node: HTMLElement, params: BuilderActionsParamsType) => {
+    if (!params.builders) return
+
     const unsubs: ActionReturn[] = []
 
     params.builders.forEach(builder => {
@@ -165,35 +167,18 @@
 
 {#if asChild}
   <slot />
-{:else if builders}
-  {#if href}
-    <a
-      {href}
-      tabindex="0"
-      class={cn(style.base, style({ variant }), className)}
-      {...$$restProps}
-      use:builderActions={{ builders }}
-    >
-      <slot />
-    </a>
-  {:else}
-    <button
-      {type}
-      tabindex="0"
-      class={cn(style.base, style({ variant }), className)}
-      {...$$restProps}
-      use:builderActions={{ builders }}
-      on:click
-    >
-      <slot />
-    </button>
-  {/if}
-{:else if href}
-  <a {href} tabindex="0" class={cn(style.base, style({ variant }), className)} {...$$restProps}>
-    <slot />
-  </a>
 {:else}
-  <button {type} tabindex="0" class={cn(style.base, style({ variant }), className)} {...$$restProps} on:click>
+  <svelte:element
+    this={href ? "a" : "button"}
+    role={href ? "a" : "button"}
+    type={href ? undefined : type}
+    href={href ? href : undefined}
+    tabindex="0"
+    class={cn(style.base, style({ variant }), className)}
+    {...$$restProps}
+    use:builderActions={{ builders }}
+    on:click
+  >
     <slot />
-  </button>
+  </svelte:element>
 {/if}

--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -24,7 +24,7 @@
   const style = tv({
     base: cn`
       transition-all
-      flex
+      inline-flex
       items-center
       justify-center
       gap-3

--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AsChildType, BuilderActionsParamsType, ExtendedVariantType } from "$lib/index.js"
+  import type { AsChildType, BuilderActionsParamsType, BuilderType, ExtendedVariantType } from "$lib/index.js"
   import { cn } from "$lib/index.js"
   import type { ActionReturn } from "svelte/action"
   import type { HTMLButtonAttributes } from "svelte/elements"
@@ -166,16 +166,32 @@
 {#if asChild}
   <slot />
 {:else if builders}
-  <button
-    {type}
-    tabindex="0"
-    class={cn(style.base, style({ variant }), className)}
-    {...$$restProps}
-    use:builderActions={{ builders }}
-    on:click
-  >
+  {#if href}
+    <a
+      {href}
+      tabindex="0"
+      class={cn(style.base, style({ variant }), className)}
+      {...$$restProps}
+      use:builderActions={{ builders }}
+    >
+      <slot />
+    </a>
+  {:else}
+    <button
+      {type}
+      tabindex="0"
+      class={cn(style.base, style({ variant }), className)}
+      {...$$restProps}
+      use:builderActions={{ builders }}
+      on:click
+    >
+      <slot />
+    </button>
+  {/if}
+{:else if href}
+  <a {href} tabindex="0" class={cn(style.base, style({ variant }), className)} {...$$restProps}>
     <slot />
-  </button>
+  </a>
 {:else}
   <button {type} tabindex="0" class={cn(style.base, style({ variant }), className)} {...$$restProps} on:click>
     <slot />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,7 +15,7 @@ export type BuilderType = {
 }
 
 export type BuilderActionsParamsType = {
-  builders: BuilderType[]
+  builders?: BuilderType[]
 }
 
 export type AlertType = {


### PR DESCRIPTION
## Changes
The following PR allows the `href` prop to be passed to the `Button` component to render an anchor tag and handles the new builders prop accordingly.