### PR TITLE
Fix role attribute for anchor elements

### DIFF
--- a/src/lib/components/Button/Button.svelte
+++ b/src/lib/components/Button/Button.svelte
@@ -170,7 +170,7 @@
 {:else}
   <svelte:element
     this={href ? "a" : "button"}
-    role={href ? "a" : "button"}
+    role={href ? undefined : "button"}
     type={href ? undefined : type}
     href={href ? href : undefined}
     tabindex="0"


### PR DESCRIPTION
## Description

This pull request addresses a bug in the `Button.Root` component's behavior when the `href` prop is provided. Previously, the rendered anchor (`<a>`) element incorrectly had a `role="a"` attribute, which is redundant and invalid markup.

```svelte
<a href="/anything" role="a">Go to any page</a>
```

The changes in this PR remove the extraneous `role` attribute from anchor elements that already have an `href` specified, adhering to best practices for accessible markup.

After this fix, the component will render as follows when `href` is provided:

```svelte
<a href="/anything">Go to any page</a>
```

By resolving this issue, we ensure that the `Button.Root` component generates semantically correct and accessible markup, improving the overall quality and standards compliance of the codebase.