### PR TITLE
Removed `arrowSize` prop from the Tooltip root component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtue-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "url": "https://github.com/virtueorg/ui"
   },

--- a/src/lib/components/ContextMenu/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu/ContextMenu.svelte
@@ -2,7 +2,7 @@
   import { type CreateContextMenuProps } from "@melt-ui/svelte"
   import ctx from "./ctx.js"
 
-  type $$Props = CreateContextMenuProps
+  type $$Props = Omit<CreateContextMenuProps, "arrowSize">
 
   export let forceVisible: $$Props["forceVisible"] = true
 

--- a/src/lib/components/DropdownMenu/DropdownMenu.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenu.svelte
@@ -2,7 +2,7 @@
   import { type CreateDropdownMenuProps } from "@melt-ui/svelte"
   import ctx from "./ctx.js"
 
-  type $$Props = CreateDropdownMenuProps
+  type $$Props = Omit<CreateDropdownMenuProps, "arrowSize">
 
   export let forceVisible: $$Props["forceVisible"] = true
 

--- a/src/lib/components/LinkPreview/LinkPreview.svelte
+++ b/src/lib/components/LinkPreview/LinkPreview.svelte
@@ -2,7 +2,7 @@
   import { type CreateLinkPreviewProps } from "@melt-ui/svelte"
   import ctx from "./ctx.js"
 
-  type $$Props = CreateLinkPreviewProps
+  type $$Props = Omit<CreateLinkPreviewProps, "arrowSize">
 
   export let forceVisible: $$Props["forceVisible"] = true
 

--- a/src/lib/components/Select/Select.svelte
+++ b/src/lib/components/Select/Select.svelte
@@ -5,7 +5,7 @@
   import { tv } from "tailwind-variants"
   import ctx from "./ctx.js"
 
-  type $$Props = CreateSelectProps<boolean> & AsChildType
+  type $$Props = Omit<CreateSelectProps<boolean>, "arrowSize"> & AsChildType
 
   export let asChild: $$Props["asChild"] = false
   export let forceVisible: $$Props["forceVisible"] = true

--- a/src/lib/components/Tooltip/Tooltip.svelte
+++ b/src/lib/components/Tooltip/Tooltip.svelte
@@ -2,7 +2,7 @@
   import { type CreateTooltipProps } from "@melt-ui/svelte"
   import ctx from "./ctx.js"
 
-  type $$Props = CreateTooltipProps
+  type $$Props = Omit<CreateTooltipProps, "arrowSize">
 
   export let forceVisible: $$Props["forceVisible"] = true
 


### PR DESCRIPTION
The following PR aims to remove the `arrowSize` prop from the Tooltip root component, because we do not expose a `<Tooltip.Arrow>` component and, we don't use the `arrow` store given by Melt UI.